### PR TITLE
Add robots.txt crawl rules

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+Allow: /posts/
+Allow: /rss.xml
+Disallow: /og-preview
+Disallow: /posts/*-og.png
+
+Sitemap: https://asynctalk.com/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Add a root `robots.txt` for the site
- Allow crawling of published posts and RSS
- Disallow preview and generated Open Graph image paths
- Include the sitemap location

## Testing
- Not run (not requested)