### PR TITLE
Add agent discovery link catalog

### DIFF
--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,19 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://AsyncTalk.com/.well-known/api-catalog",
+      "item": [
+        {
+          "href": "https://AsyncTalk.com/rss.xml",
+          "type": "application/rss+xml"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://AsyncTalk.com/posts",
+          "type": "text/html"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a static RFC 9727 Linkset catalog at `/.well-known/api-catalog`
- Advertise the RSS feed as a machine-readable entrypoint for agent discovery
- Include `/posts` as the service documentation target

## Testing
- `pnpm astro check`
- `pnpm build`