### PR TITLE
Add MCP server card endpoint

### DIFF
--- a/src/pages/.well-known/mcp/server-card.json.ts
+++ b/src/pages/.well-known/mcp/server-card.json.ts
@@ -1,0 +1,36 @@
+import type { APIRoute } from "astro";
+
+export const prerender = true;
+
+const serverCard = {
+  $schema: "https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json",
+  version: "1.0",
+  protocolVersion: "2025-06-18",
+  serverInfo: {
+    name: "asynctalk",
+    title: "AsyncTalk",
+    version: "2.0.0",
+  },
+  description: "AsyncTalk 是一档中文 Web 开发播客。",
+  documentationUrl: "https://asynctalk.com",
+  transport: {
+    type: "streamable-http",
+    endpoint: "/mcp",
+  },
+  capabilities: {
+    tools: {},
+    prompts: {},
+    resources: {},
+  },
+};
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify(serverCard, null, 2), {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "public, max-age=3600",
+      "Content-Type": "application/json; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- Add `/.well-known/mcp/server-card.json` as a prerendered Astro endpoint
- Publish SEP-1649 server card metadata with `serverInfo`, transport endpoint, and capabilities
- Set JSON response headers for discovery and caching

## Testing
- `pnpm astro check`
- `pnpm build`