### PR TITLE
add EP65: Markdown 没凉,但 HTML 要上桌

### DIFF
--- a/src/content/posts/ep65.mdx
+++ b/src/content/posts/ep65.mdx
@@ -11,10 +11,13 @@ season: 3
 episodeNumber: 65
 episodeType: full
 excerpt: "EP65 Markdown 没凉,但 HTML 要上桌：AI 输出格式的一场小进化"
+url: https://www.xiaoyuzhoufm.com/episode/6a0c5152e443f6948c8d4554
 size: 0
 duration: 0
 explicit: false
+xyzLink: https://www.xiaoyuzhoufm.com/episode/6a0c5152e443f6948c8d4554
 youtubeId: ecPPN6PVOfU
+biliUrl: //player.bilibili.com/player.html?isOutside=true&aid=116596701926636&bvid=BV1htLK6GEBV&cid=38433587591&p=1
 categories:
     - html
     - markdown

--- a/src/content/posts/ep65.mdx
+++ b/src/content/posts/ep65.mdx
@@ -1,0 +1,49 @@
+---
+type: podcast-episode
+status: published
+slug: /posts/ep65
+guid: 65
+title: "EP65 Markdown 没凉,但 HTML 要上桌"
+subtitle: "AI 输出格式的一场小进化"
+publicationDate: 2026-05-18 14:00:00
+author: AnnatarHe
+season: 3
+episodeNumber: 65
+episodeType: full
+excerpt: "EP65 Markdown 没凉,但 HTML 要上桌：AI 输出格式的一场小进化"
+size: 0
+duration: 0
+explicit: false
+youtubeId: ecPPN6PVOfU
+categories:
+    - html
+    - markdown
+    - mdx
+    - ai
+    - llm
+    - claude-code
+    - anthropic
+    - frontend
+---
+
+### 📕 Shownotes
+
+AI 输出 Markdown 你是不是已经看腻了？
+
+来自 Anthropic 的 Thariq 最近写了篇文章，提出一个挺有意思的观点：HTML 正在取代 Markdown，成为大模型更好的表达语言。
+
+这期我们聊聊：
+
+- ✦ 为什么 Markdown 一开始成了 AI 的默认输出格式
+- ✦ Markdown 的天花板：code diff、依赖图、design token 全都"压扁"了
+- ✦ HTML 怎么把可读性拉满，代价是 token 爆炸
+- ✦ 用 Claude Code 实测：让它用 HTML 解释 async task 流程，架构图、时序图、代码片段一气呵成
+- ✦ 我心中的"隐藏大佬"——MDX：Markdown 的强化版，该用文字用文字，该用组件上组件
+
+简单说：Markdown 没过气，只是角色变了。
+
+你怎么看 AI 时代的输出格式？有没有更好的方案？评论区聊聊👇
+
+关注【异步聊技术 AsyncTalk】，每期聊点有趣又有料的技术。
+
+BGM by Otologic


### PR DESCRIPTION
## Summary
- 新增 EP65 节目：《Markdown 没凉,但 HTML 要上桌》——AI 输出格式的一场小进化
- 聊聊为什么 HTML 正在取代 Markdown 成为大模型更好的表达语言，以及 MDX 作为"隐藏大佬"的价值
- YouTube 已上线：https://youtu.be/ecPPN6PVOfU（xyzLink 和 biliUrl 待补充）

## Test plan
- [x] `pnpm astro check` 通过（0 errors）
- [ ] 本地 `pnpm dev` 预览节目页面渲染
- [ ] 确认 RSS feed 正常生成
- [ ] 后续补充 xyzLink（小宇宙）和 biliUrl（B站）

https://claude.ai/code/session_01TdsmAMePh4cghdKgRhiurG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdsmAMePh4cghdKgRhiurG)_