### PR TITLE
add EP66: 用 TS 写命令行工具，比你想的简单多了

### DIFF
--- a/src/content/posts/ep66.mdx
+++ b/src/content/posts/ep66.mdx
@@ -1,0 +1,46 @@
+---
+type: podcast-episode
+status: published
+slug: /posts/ep66
+guid: 66
+title: "EP66 用 TS 写命令行工具，比你想的简单多了"
+subtitle: "Bun 打包成单文件 binary，goreleaser 一把梭搞定签名、公证、分发"
+publicationDate: 2026-06-02 14:00:00
+author: AnnatarHe
+season: 3
+episodeNumber: 66
+episodeType: full
+excerpt: "EP66 用 TS 写命令行工具，比你想的简单多了：Bun 打包成单文件 binary，goreleaser 一把梭搞定签名、公证、分发"
+url: https://www.xiaoyuzhoufm.com/episode/6a1eb84b92551efcff54fc0f
+size: 0
+duration: 0
+explicit: false
+xyzLink: https://www.xiaoyuzhoufm.com/episode/6a1eb84b92551efcff54fc0f
+youtubeId: pVQViO74jLE
+biliUrl: //player.bilibili.com/player.html?isOutside=true&aid=116675856832249&bvid=BV1ugVf6mEAF&cid=38781848002&p=1
+categories:
+    - cli
+    - typescript
+    - bun
+    - ink
+    - goreleaser
+    - claude-code
+    - tooling
+    - frontend
+---
+
+### 📕 Shownotes
+
+万物皆可 CLI 的时代（尤其 AI 起来之后），怎么写一个好用的命令行工具？这期聊点不一样的——不碰 C/Go/Rust，直接用 TypeScript + Bun 也能整一个能发给用户的 CLI。
+
+从 `bun init` 起步，命令解析交给 citty，界面渲染用 Ink（对，就是用 React 写 TUI），最后 `bun build --compile` 一把打成单文件。57 兆是大了点，但是它能用（doge）。
+
+最折磨人的签名 + 公证怎么办？goreleaser 从 2.6 开始把 bun 当一等公民支持，checksum、changelog、打包、公证、Homebrew 分发全给你包圆了。顺带提一句：Mac 开发者证书 99 刀一年，这钱是真省不掉。
+
+下期预告：怎么把这整套编译流程自动化掉。
+
+你写过 / 用过哪些有意思的 CLI？评论区聊聊～
+
+关注【异步聊技术 AsyncTalk】，每期聊点有趣又有料的技术。
+
+BGM by Otologic


### PR DESCRIPTION
## 概要 / Summary

新增播客单集 **EP66：用 TS 写命令行工具，比你想的简单多了**，文件为 `src/content/posts/ep66.mdx`，沿用现有单集模板。

主题：用 TypeScript + Bun 写命令行工具，命令解析用 citty、TUI 用 Ink，`bun build --compile` 打成单文件 binary，再用 goreleaser 搞定 checksum、changelog、签名、公证与 Homebrew 分发。

## 元数据 / Metadata

| 字段 | 值 |
|---|---|
| 标题 | EP66 用 TS 写命令行工具，比你想的简单多了 |
| 副标题 | Bun 打包成单文件 binary，goreleaser 一把梭搞定签名、公证、分发 |
| 发布日期 | 2026-06-02 14:00:00 |
| 状态 | published |
| 小宇宙 | https://www.xiaoyuzhoufm.com/episode/6a1eb84b92551efcff54fc0f |
| YouTube | `pVQViO74jLE` |
| Bilibili | `BV1ugVf6mEAF` |
| 分类 | cli, typescript, bun, ink, goreleaser, claude-code, tooling, frontend |

## 说明 / Notes

- Hashtag 按现有约定映射为小写英文 `categories`，去掉了品牌/通用标签（`#程序员`、`#AsyncTalk`、`#异步聊技术`）。
- shownotes 里的命令 `bun init` / `bun build --compile` 用反引号包成了行内代码——否则站点默认的 smartypants 会把 `--` 吞掉，命令会变成 `bun build compile`。这与现有单集对 `sudo`、`execCommand` 等的处理一致。

## 验证 / Verification

- ✅ `pnpm astro check` — 0 errors（frontmatter 通过 content schema 校验）
- ✅ dev server 渲染 `/posts/ep66`：标题、shownotes、YouTube + Bilibili 嵌入均正常；单集按 `publicationDate` 排在 `/posts` 列表最前
- ⚠️ `pnpm build` 在 OG 图片生成阶段失败，原因是当前沙箱网络策略拦截了 `ik.imagekit.io` 上的 logo（HTTP 403）。该问题影响**所有**单集（构建在 ep0 即中断），与本次内容改动无关。

https://claude.ai/code/session_01LHYnpDfJS98GD99cvCzXZb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHYnpDfJS98GD99cvCzXZb)_