### PR TITLE
add EP67: 写完代码到上线,中间到底发生了啥

### DIFF
--- a/src/content/posts/ep67.mdx
+++ b/src/content/posts/ep67.mdx
@@ -1,0 +1,44 @@
+---
+type: podcast-episode
+status: published
+slug: /posts/ep67
+guid: 67
+title: "EP67 写完代码到上线,中间到底发生了啥"
+subtitle: "GitHub Actions + Claude 代码审查 + 自动发布,从 push 到上线全流程拆给你看"
+publicationDate: 2026-06-10 14:00:00
+author: AnnatarHe
+season: 3
+episodeNumber: 67
+episodeType: full
+excerpt: "EP67 写完代码到上线,中间到底发生了啥：GitHub Actions + Claude 代码审查 + 自动发布,从 push 到上线全流程拆给你看"
+url: https://www.xiaoyuzhoufm.com/episode/6a2945a00289864adc578925
+size: 0
+duration: 0
+explicit: false
+xyzLink: https://www.xiaoyuzhoufm.com/episode/6a2945a00289864adc578925
+youtubeId: 4ff_lHEXwHQ
+biliUrl: //player.bilibili.com/player.html?isOutside=true&aid=116721507638067&bvid=BV1KcES6hENm&cid=38994642831&p=1
+categories:
+    - github-actions
+    - ci-cd
+    - devops
+    - claude-code
+    - codecov
+    - release-please
+    - docker
+    - backend
+---
+
+### 📕 Shownotes
+
+写完代码 git push 上去之后，到真正上线之前，中间到底发生了什么？这期我直接打开自己项目的 GitHub Actions，把整条 CI 流水线扒开给你看。
+
+从 push、用 GitHub CLI 开 PR，到 Claude Code 自动 review 帮我抓空指针、codecov 盯测试覆盖率，再到 Release Please 按语义化 commit 自动生成版本、打 tag、构建 Docker image——全流程串一遍，一个环节都不跳。
+
+Runner 配合 GitHub Actions 本身慷慨的免费额度，轻量项目基本能零成本跑起一整套 CI。性能 OK 不算顶，但够用，关键是省钱。
+
+如果你有更顺手的环节或者觉得哪里还能优化，评论区聊聊，也欢迎甩给我更好的玩法。
+
+关注【异步聊技术 AsyncTalk】，每期聊点有趣又有料的技术。
+
+BGM by Otologic


### PR DESCRIPTION
## Summary

新增 EP67 播客文章 `src/content/posts/ep67.mdx`：

- **标题**: EP67 写完代码到上线,中间到底发生了啥
- **副标题**: GitHub Actions + Claude 代码审查 + 自动发布,从 push 到上线全流程拆给你看
- **发布时间**: 2026-06-10 14:00:00
- **链接**: 小宇宙 / YouTube (`4ff_lHEXwHQ`) / B 站 (BV1KcES6hENm)
- Frontmatter 与 shownotes 格式遵循 ep66 的既有模式

## Verification

- `pnpm astro check`: 0 errors, 0 warnings
- `pnpm build` 在本沙箱环境中因网络策略拦截 `ik.imagekit.io`（OG 图 logo 源）而失败，该问题在 ep0 上同样复现，与本次改动无关

https://claude.ai/code/session_01FKJVEpfhpfay1FWg39HRnE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKJVEpfhpfay1FWg39HRnE)_